### PR TITLE
NoErrorsPlugin is not needed with hot/only-dev-server

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,7 @@ gulp.task('webpack-dev-server', function(callback) {
 	browserConfig.devtool = 'eval';
 	browserConfig.debug = true;
   browserConfig.plugins = browserConfig.plugins || [];
-  browserConfig.plugins = browserConfig.plugins.concat([new webpack.HotModuleReplacementPlugin(), new webpack.NoErrorsPlugin()]);
+  browserConfig.plugins = browserConfig.plugins.concat([new webpack.HotModuleReplacementPlugin()]);
 	browserConfig.entry = [
 		'webpack-dev-server/client?http://localhost:8080', 'webpack/hot/only-dev-server', './app/jsx/app.jsx'
 	];


### PR DESCRIPTION
This is something silly I've been doing and recommending for a long time. Sorry! There's no need for `NoErrorsPlugin` if you use `hot/only-dev-server`. Hot updates won't blow your app away if you make a syntax error, but at least you'll see the error in the DevTools console! And the subsequent hot updates will just work when you fix that error.

Please verify that this is indeed the case for you. (I don't know, it certainly works this way for my projects, but then maybe Webpack changed the behavior in some version? Just make sure it really works as I describe above.)
